### PR TITLE
Fix company creation

### DIFF
--- a/Assets/Scripts/TwitchDevCompany/Classes/CompanyClass.cs
+++ b/Assets/Scripts/TwitchDevCompany/Classes/CompanyClass.cs
@@ -45,7 +45,7 @@ public class CompanyClass
 	public bool CanAddProject => (ProjectCount < maxConcurrentProjects);
 	public int ProjectCount => projects.Count;
 
-	public int money { get; private set; }
+	public int money { get; set; }
 	public void AddMoney(int amount) => money += amount;
 	public void SpendMoney(int amount) => money -= amount;
 	public bool HasEnoughMoney(int amount) => (money >= amount);

--- a/Assets/Scripts/TwitchDevCompany/CommandController.cs
+++ b/Assets/Scripts/TwitchDevCompany/CommandController.cs
@@ -535,6 +535,13 @@ public class CommandController : MonoBehaviour {
                         developers[developer].UpdateCompany(newName); //Make a function
                     }
 
+                    //Create a new CompanyClass
+                    company = companies[companyName];
+
+                    //Remove the old company and add the new one to update the Key
+                    companies.Remove(companyName);
+                    companies.Add(newName, company);
+
                     client.SendWhisper(username, "You have changed the name of the company to " + newName);
                 }
                 else {


### PR DESCRIPTION
- If you changed the name, produced an exception when you tried to do anything involved with the old name.
This is because the companies dictionary key wasn't updated to match the new name.

- If you tried to load the companies money after launching, it would reset it to 0.
This was because the money had set to private.