### PR TITLE
Naming consistencies

### DIFF
--- a/Assets/ScriptableObjects/_Scripts/FeatureList.cs
+++ b/Assets/ScriptableObjects/_Scripts/FeatureList.cs
@@ -5,6 +5,6 @@ using UnityEngine;
 [CreateAssetMenu(menuName = "Create/Database/FeatureList")]
 public class FeatureList : ScriptableObject
 {
-    public List<String> featureNames = new List<String>();
+    public List<string> featureNames = new List<string>();
     public List<FeatureSO> features = new List<FeatureSO>();
 }

--- a/Assets/_Scripts/Project/Features/Feature.cs
+++ b/Assets/_Scripts/Project/Features/Feature.cs
@@ -1,12 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
 
 [Serializable]
 public class Feature
 {
     public string featureName;
-    public FeatureQuality maxQuality = FeatureQuality.good;
-    public FeatureQuality featureQuality = FeatureQuality.trulyAbysmal;
+    public FeatureQuality maxQuality = FeatureQuality.Good;
+    public FeatureQuality featureQuality = FeatureQuality.TrulyAbysmal;
     
     public int qualityCounter = 0;
 
@@ -25,22 +24,22 @@ public class Feature
 
 public enum FeatureQuality
 {
-    nothing,
-    trulyAbysmal,
-    horrendous,
-    dreadful,
-    terrible,
-    poor,
-    mediocre,
-    decent,
-    pleasant,
-    good,
-    sweet,
-    splendid,
-    awesome,
-    great,
-    terrific,
-    wonderful,
-    incredible,
-    perfect,
+    Nothing,
+    TrulyAbysmal,
+    Horrendous,
+    Dreadful,
+    Terrible,
+    Poor,
+    Mediocre,
+    Decent,
+    Pleasant,
+    Good,
+    Sweet,
+    Splendid,
+    Awesome,
+    Great,
+    Terrific,
+    Wonderful,
+    Incredible,
+    Perfect,
 }


### PR DESCRIPTION
* enums start with a capital. (Although some people put them as all
caps. But definitely not camelCase like variable names)

* featureNames now uses string instead of String for consistency. String
is just an alias for string and is not used anywhere else