### PR TITLE
Split off enums from other classes

### DIFF
--- a/Assets/_Scripts/Enums.meta
+++ b/Assets/_Scripts/Enums.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: ef6e0277917192247a9d00f30d380451
+folderAsset: yes
+timeCreated: 1508665698
+licenseType: Free
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Scripts/Enums/CompanyCategories.cs
+++ b/Assets/_Scripts/Enums/CompanyCategories.cs
@@ -1,3 +1,4 @@
 ﻿public enum Categories
 {
+    Games
 }

--- a/Assets/_Scripts/Enums/CompanyCategories.cs
+++ b/Assets/_Scripts/Enums/CompanyCategories.cs
@@ -1,0 +1,3 @@
+﻿public enum Categories
+{
+}

--- a/Assets/_Scripts/Enums/CompanyCategories.cs.meta
+++ b/Assets/_Scripts/Enums/CompanyCategories.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 3014f4ed56e20af4387dae09b4fc2a40
+timeCreated: 1508666009
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Scripts/Enums/DeveloperPosition.cs
+++ b/Assets/_Scripts/Enums/DeveloperPosition.cs
@@ -1,0 +1,6 @@
+﻿public enum DeveloperPosition
+{
+    Designer,
+    Developer,
+    Artist
+}

--- a/Assets/_Scripts/Enums/DeveloperPosition.cs.meta
+++ b/Assets/_Scripts/Enums/DeveloperPosition.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 15f798913a5cf684bbe8b2b491391da1
+timeCreated: 1508665733
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Scripts/Enums/FeatureQuality.cs
+++ b/Assets/_Scripts/Enums/FeatureQuality.cs
@@ -1,0 +1,21 @@
+﻿public enum FeatureQuality
+{
+    Nothing,
+    TrulyAbysmal,
+    Horrendous,
+    Dreadful,
+    Terrible,
+    Poor,
+    Mediocre,
+    Decent,
+    Pleasant,
+    Good,
+    Sweet,
+    Splendid,
+    Awesome,
+    Great,
+    Terrific,
+    Wonderful,
+    Incredible,
+    Perfect,
+}

--- a/Assets/_Scripts/Enums/FeatureQuality.cs.meta
+++ b/Assets/_Scripts/Enums/FeatureQuality.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 54ecf7c5a425d14489c878099baeae45
+timeCreated: 1508665908
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Scripts/Project/Features/Feature.cs
+++ b/Assets/_Scripts/Project/Features/Feature.cs
@@ -21,25 +21,3 @@ public class Feature
     public int artPointsRequired;
     public int artPoints = 0;
 }
-
-public enum FeatureQuality
-{
-    Nothing,
-    TrulyAbysmal,
-    Horrendous,
-    Dreadful,
-    Terrible,
-    Poor,
-    Mediocre,
-    Decent,
-    Pleasant,
-    Good,
-    Sweet,
-    Splendid,
-    Awesome,
-    Great,
-    Terrific,
-    Wonderful,
-    Incredible,
-    Perfect,
-}

--- a/Assets/_Scripts/Project/ProjectClass.cs
+++ b/Assets/_Scripts/Project/ProjectClass.cs
@@ -10,10 +10,7 @@ public class ProjectClass
     public string projectLead;
     public Dictionary<string, DeveloperPosition> developers = new Dictionary<string, DeveloperPosition>();
 
-    public enum Categories
-    {
-        games,
-    };
+    
     public Categories category;
 
     public bool sequel = false;

--- a/Assets/_Scripts/Project/ProjectManager.cs
+++ b/Assets/_Scripts/Project/ProjectManager.cs
@@ -140,7 +140,7 @@ public class ProjectManager : MonoBehaviour
 
                 //Create the project
                 project = new ProjectClass(projectName, username); //Reason we store name over ID is because project is saved in their profile anyway, means we can look back at it easier and see what they worked on
-                project.category = ProjectClass.Categories.games;
+                project.category = Categories.Games;
 
                 client.SendWhisper(username, WhisperMessages.Project.Start.success(projectName), Timers.ProjectApplication);
                 client.SendMessage(WhisperMessages.Project.Start.canApply(username));
@@ -328,11 +328,4 @@ public class ProjectManager : MonoBehaviour
                 break;
         }
     }
-}
-
-public enum DeveloperPosition
-{
-    Designer,
-    Developer,
-    Artist
 }


### PR DESCRIPTION
* This makes enums easier to find and edit without breaking other
things. This also means that those classes can be modified as well as
these enums without conflicts.