### PR TITLE
QuizClient Updated and PostBuildActions Added

### DIFF
--- a/Assets/_Scripts/PostBuildActions.cs
+++ b/Assets/_Scripts/PostBuildActions.cs
@@ -1,0 +1,39 @@
+﻿using System.IO;
+
+#if UNITY_EDITOR
+using UnityEditor;
+using UnityEditor.Callbacks;
+#endif
+
+using UnityEngine;
+
+public class PostBuildActions : MonoBehaviour 
+{
+    #if UNITY_EDITOR
+    [PostProcessBuild(1)]
+	public static void DestoryStreamingAssets(BuildTarget target, string buildPath)
+    {
+        if (target == BuildTarget.StandaloneWindows ||
+            target == BuildTarget.StandaloneWindows64 ||
+            target == BuildTarget.StandaloneOSXIntel ||
+            target == BuildTarget.StandaloneOSXIntel64 ||
+            target == BuildTarget.StandaloneOSXUniversal)
+        {
+            string buildName = Path.GetFileNameWithoutExtension(buildPath);
+            string buildFolder = Path.GetDirectoryName(buildPath);
+            string buildDataFolder = Path.Combine(buildFolder, $"{buildName}_Data");
+            string buildStreamingAssetsFolder = Path.Combine(buildDataFolder, "StreamingAssets");
+
+            if (Directory.Exists(buildStreamingAssetsFolder) == true)
+            {
+                foreach (string file in Directory.GetFiles(buildStreamingAssetsFolder))
+                {
+                    File.Delete(file);
+                }
+
+                Debug.Log("[POST-BUILD] The streaming assets folder for the build has been deleted!");
+            }
+        }
+    }
+    #endif
+}

--- a/Assets/_Scripts/PostBuildActions.cs
+++ b/Assets/_Scripts/PostBuildActions.cs
@@ -31,7 +31,7 @@ public class PostBuildActions : MonoBehaviour
                     File.Delete(file);
                 }
 
-                Debug.Log("[POST-BUILD] The streaming assets folder for the build has been deleted!");
+                Debug.Log("[POST-BUILD] All of the files within the StreamingAssets folder have been deleted!");
             }
         }
     }

--- a/Assets/_Scripts/PostBuildActions.cs.meta
+++ b/Assets/_Scripts/PostBuildActions.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: c1905a64ddc389c42a823eca799ed13e
+timeCreated: 1508748202
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Tools/APIs/PasteBinClient.cs
+++ b/Assets/_Tools/APIs/PasteBinClient.cs
@@ -37,14 +37,16 @@ namespace PasteBin
             parameters[ApiParameters.UserName] = userName;
             parameters[ApiParameters.UserPassword] = password;
 
-            WebClient client = new WebClient();
-            byte[] bytes = client.UploadValues(_apiLoginUrl, parameters);
-            string resp = GetResponseText(bytes);
-            if (resp.StartsWith("Bad API request"))
-                throw new PasteBinApiException(resp);
+            using (WebClient client = new WebClient())
+            {
+                byte[] bytes = client.UploadValues(_apiLoginUrl, parameters);
+                string resp = GetResponseText(bytes);
+                if (resp.StartsWith("Bad API request"))
+                    throw new PasteBinApiException(resp);
 
-            _userName = userName;
-            _apiUserKey = resp;
+                _userName = userName;
+                _apiUserKey = resp;
+            }
         }
 
         public void Logout()
@@ -69,12 +71,14 @@ namespace PasteBin
             SetIfNotEmpty(parameters, ApiParameters.PasteExpireDate, FormatExpireDate(entry.Expiration));
             SetIfNotEmpty(parameters, ApiParameters.UserKey, _apiUserKey);
 
-            WebClient client = new WebClient();
-            byte[] bytes = client.UploadValues(_apiPostUrl, parameters);
-            string resp = GetResponseText(bytes);
-            if (resp.StartsWith("Bad API request"))
-                throw new PasteBinApiException(resp);
-            return resp;
+            using (WebClient client = new WebClient())
+            {
+                byte[] bytes = client.UploadValues(_apiPostUrl, parameters);
+                string resp = GetResponseText(bytes);
+                if (resp.StartsWith("Bad API request"))
+                    throw new PasteBinApiException(resp);
+                return resp;
+            }
         }
 
         private static string FormatExpireDate(PasteBinExpiration expiration)

--- a/Assets/_Tools/APIs/QuizClient.cs
+++ b/Assets/_Tools/APIs/QuizClient.cs
@@ -21,9 +21,11 @@ namespace Quiz
             string url = _apiTokenUrl + ApiParameters.TokenRequest;
             Uri uri = new Uri(url);
 
-            WebClient client = new WebClient();
-            string resp = await client.DownloadStringTaskAsync(uri);
-            _sessionToken = RequestSession(resp);
+            using (WebClient client = new WebClient())
+            {
+                string resp = await client.DownloadStringTaskAsync(uri);
+                _sessionToken = RequestSession(resp);
+            }
         }
 
         public async Task ResetToken()
@@ -35,9 +37,11 @@ namespace Quiz
 
             Uri uri = new Uri(url);
 
-            WebClient client = new WebClient();
-            string resp = await client.DownloadStringTaskAsync(uri);
-            _sessionToken = RequestSession(resp);
+            using (WebClient client = new WebClient())
+            {
+                string resp = await client.DownloadStringTaskAsync(uri);
+                _sessionToken = RequestSession(resp);
+            }
         }
 
         public async Task<RootObject> GenerateQuestions(int amount, QuizCategories category, QuizDifficulty difficulty, QuizType type)
@@ -80,10 +84,12 @@ namespace Quiz
 
             Uri uri = new Uri(url);
 
-            WebClient client = new WebClient();
-            string resp = await client.DownloadStringTaskAsync(uri);
-            RootObject questions = GetQuestions(resp);
-            return questions;
+            using (WebClient client = new WebClient())
+            {
+                string resp = await client.DownloadStringTaskAsync(uri);
+                RootObject questions = GetQuestions(resp);
+                return questions;
+            }
         }
 
         private string RequestSession(string resp)

--- a/Assets/_Tools/RandomGenerator/QuizHandler.cs
+++ b/Assets/_Tools/RandomGenerator/QuizHandler.cs
@@ -45,7 +45,7 @@ public class QuizHandler : MonoBehaviour
 
     public async void AddQuestions()
     {
-        RootObject questions;
+        Results questions;
 
         try
         {


### PR DESCRIPTION
**Added PostBuildActions**

This class will be for methods which need to run post building the
application.

Currently has:
* A method to delete all files within the StreamingAssets folder after
building. This is so we can keep all of our own settings locally and it
wont be transferred into the build. (Works for all PC and Mac builds, struggled to find info about linux builds but I'm sure it could be added super easily)

**Updated QuizClient**

* Removed redundant code. (There were empty ifs)
* Renamed RootObject to something more sensible. (Questions)
* Removed Uri's from the API calls and simply passed in the URL as a
string instead, which is allowed
* Updated every instance of WebClient to be contained within a using
statement. This makes sure that the WebClient is automatically disposed
afterwards. Without it, there could be potential for a memory leak.