### PR TITLE
ToLowers are now string.Equals

### DIFF
--- a/Assets/_Scripts/CommandController.cs
+++ b/Assets/_Scripts/CommandController.cs
@@ -34,7 +34,7 @@ public class CommandController : MonoBehaviour
     public static string GetID(string username)
     {
         return viewers
-            .Where(i => (username.ToLower() == i.username.ToLower()))
+            .Where(i => username.EqualsOrdinalIgnoreCase(i.username))
             .ToList()[0].id;
     }
 
@@ -45,7 +45,7 @@ public class CommandController : MonoBehaviour
     public static bool DoesUsernameExist(string username)
     {
         return viewers
-            .Where(i => (i.username.ToLower() == username.ToLower()))
+            .Where(i => username.EqualsOrdinalIgnoreCase(i.username))
             .ToList()
             .Count > 0;
     }

--- a/Assets/_Scripts/Company/CompanyInvite.cs
+++ b/Assets/_Scripts/Company/CompanyInvite.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -26,7 +27,7 @@ public class CompanyInvite : MonoBehaviour
             return;
         }
 
-        if (username.ToLower() == invitedUsername.ToLower())
+        if (username.EqualsOrdinalIgnoreCase(invitedUsername))
         {
             client.SendWhisper(username, WhisperMessages.Company.Invite.self);
             return;

--- a/Assets/_Scripts/ExtensionMethods/StringExtensions.cs
+++ b/Assets/_Scripts/ExtensionMethods/StringExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Globalization;
+﻿using System;
+using System.Globalization;
 using System.Linq;
 
 public static class StringExtensions
@@ -28,5 +29,29 @@ public static class StringExtensions
     public static string CapitaliseAllWords(this string s)
     {
         return textInfo.ToTitleCase(s);
+    }
+
+    /// <summary>
+    /// This is shorthand syntax for comparing a string using the OrdinalIgnoreCase enum
+    /// </summary>
+    /// <param name="s"></param>
+    /// <param name="compare"></param>
+    /// <returns></returns>
+    public static bool EqualsOrdinalIgnoreCase(this string s, string compare)
+    {
+        return s.Equals(compare, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// This is shorthand syntax for comparing a string to a DeveloperPosition.
+    /// It means you dont have to keep casting it to a string as that occurs
+    /// within the method
+    /// </summary>
+    /// <param name="s"></param>
+    /// <param name="compare"></param>
+    /// <returns></returns>
+    public static bool EqualsOrdinalIgnoreCase(this string s, DeveloperPosition compare)
+    {
+        return s.Equals(compare.ToString(), StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/Assets/_Scripts/Project/ProjectApply.cs
+++ b/Assets/_Scripts/Project/ProjectApply.cs
@@ -42,19 +42,19 @@ public class ProjectApply : MonoBehaviour
 
         string position = splitWhisper[1];
 
-        if (position.ToLower() == DeveloperPosition.Designer.ToString().ToLower())
+        if (position.EqualsOrdinalIgnoreCase(DeveloperPosition.Designer))
         {
             project.AddApplicant(username, DeveloperPosition.Designer);
             client.SendWhisper(username, WhisperMessages.Project.Apply.success);
         }
 
-        else if (position.ToLower() == DeveloperPosition.Developer.ToString().ToLower())
+        else if (position.EqualsOrdinalIgnoreCase(DeveloperPosition.Developer))
         {
             project.AddApplicant(username, DeveloperPosition.Developer);
             client.SendWhisper(username, WhisperMessages.Project.Apply.success);
         }
 
-        else if (position.ToLower() == DeveloperPosition.Artist.ToString().ToLower())
+        else if (position.EqualsOrdinalIgnoreCase(DeveloperPosition.Artist))
         {
             project.AddApplicant(username, DeveloperPosition.Artist);
             client.SendWhisper(username, WhisperMessages.Project.Apply.success);

--- a/Assets/_Scripts/Project/ProjectRecruit.cs
+++ b/Assets/_Scripts/Project/ProjectRecruit.cs
@@ -78,7 +78,7 @@ public class ProjectRecruit : MonoBehaviour
             return;
         }
 
-        if (splitWhisper[0].ToLower() == DeveloperPosition.Designer.ToString().ToLower())
+        if (splitWhisper[0].EqualsOrdinalIgnoreCase(DeveloperPosition.Designer))
         {
             project.designAI += number;
             project.cost += cost;
@@ -87,7 +87,7 @@ public class ProjectRecruit : MonoBehaviour
             client.SendWhisper(username, WhisperMessages.Project.Apply.success);
         }
 
-        else if (splitWhisper[0].ToLower() == DeveloperPosition.Developer.ToString().ToLower())
+        else if (splitWhisper[0].EqualsOrdinalIgnoreCase(DeveloperPosition.Developer))
         {
             project.developAI += number;
             project.cost += cost;
@@ -96,7 +96,7 @@ public class ProjectRecruit : MonoBehaviour
             client.SendWhisper(username, WhisperMessages.Project.Apply.success);
         }
 
-        else if (splitWhisper[0].ToLower() == DeveloperPosition.Artist.ToString().ToLower())
+        else if (splitWhisper[0].EqualsOrdinalIgnoreCase(DeveloperPosition.Artist))
         {
             project.artAI += number;
             project.cost += cost;


### PR DESCRIPTION
I have added a method within the StringExtensions class which allows for
a shorter syntax when comparing strings. The EqualsOrdinalIgnoreCase
method compares 2 strings (or string and developer position) making sure
to not be case sensitive.

This is preferred for a few reasons:
* It makes the intent more obvious, to compare 2 strings while ignoring
the case of both.
* It is so much more performant -
http://www.pvladov.com/2012/09/case-insensitive-string-comparison.html
* Makes modifications/updates easier, only have to change the method in a single central
location as opposed to many.